### PR TITLE
chore: remove unused configuration imports

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 from datasets import load_dataset
-from omegaconf import DictConfig
 from src.config_schema import AppConfig # ← この行を追加
 
 def load_and_prepare_dataset(cfg: AppConfig):

--- a/src/results.py
+++ b/src/results.py
@@ -15,7 +15,6 @@ from sklearn.metrics import accuracy_score, classification_report, ConfusionMatr
 import tempfile
 import mlflow
 from tqdm import tqdm
-from omegaconf import OmegaConf # 修正2のために追加
 from .config_schema import AppConfig
 from cebra.integrations.sklearn.metrics import consistency_score
 from cebra import plot_consistency
@@ -195,3 +194,4 @@ def run_consistency_check(X_train, X_valid, cfg: AppConfig, output_dir: Path):
         # Figureを閉じる
         plt.close(ax.figure)
         mlflow.log_artifact(str(plot_path), "plots")
+


### PR DESCRIPTION
## Summary
- remove unused DictConfig from data module
- drop unused OmegaConf import from results module

## Testing
- `flake8 src/data.py src/results.py --select=F401`


------
https://chatgpt.com/codex/tasks/task_b_689de59831b08322a3d34dbf49449ed9