### PR TITLE
Fix InfoNCE import for CEBRA training

### DIFF
--- a/src/cebra_trainer.py
+++ b/src/cebra_trainer.py
@@ -115,7 +115,7 @@ def train_cebra(X_vectors, labels, cfg: AppConfig, output_dir):
     elif cfg.cebra.conditional != "none":
         raise ValueError("`labels` are required for conditional training")
 
-    from cebra.models.criterions import FixedCosineInfoNCE
+    from cebra.models.criterions import FixedCosineInfoNCE as InfoNCE
 
     tensors = [torch.as_tensor(X_vectors, dtype=torch.float32)]
     if labels is not None:


### PR DESCRIPTION
## Summary
- Alias `FixedCosineInfoNCE` as `InfoNCE` so the trainer can construct the loss function without a `NameError`

## Testing
- `python -m py_compile src/cebra_trainer.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689e0948eb1c8322b203b1f80d3c42d7