### PR TITLE
Improve supervised CEBRA training with explicit pos/neg sampling

### DIFF
--- a/tests/test_cebra_trainer.py
+++ b/tests/test_cebra_trainer.py
@@ -1,0 +1,54 @@
+import numpy as np
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.cebra_trainer import train_cebra
+from src.config_schema import (
+    AppConfig,
+    PathsConfig,
+    DatasetConfig,
+    EmbeddingConfig,
+    CEBRAConfig,
+    EvaluationConfig,
+    MLflowConfig,
+    ConsistencyCheckConfig,
+    VisualizationConfig,
+)
+
+
+def make_config(batch_size: int) -> AppConfig:
+    cfg = AppConfig(
+        paths=PathsConfig(embedding_cache_dir=""),
+        dataset=DatasetConfig(
+            name="dummy",
+            hf_path="",
+            text_column="text",
+            label_column="label",
+            label_map={0: "a", 1: "b"},
+            visualization=VisualizationConfig(emotion_colors={}, emotion_order=[]),
+        ),
+        embedding=EmbeddingConfig(name="dummy", type="dummy", model_name="dummy"),
+        cebra=CEBRAConfig(
+            output_dim=2,
+            max_iterations=1,
+            conditional="discrete",
+            params={"batch_size": batch_size},
+        ),
+        evaluation=EvaluationConfig(test_size=0.2, random_state=0, knn_neighbors=1),
+        mlflow=MLflowConfig(experiment_name="", run_name=""),
+        consistency_check=ConsistencyCheckConfig(),
+    )
+    cfg.device = "cpu"
+    return cfg
+
+
+def test_train_one_step_no_type_error():
+    cfg = make_config(batch_size=8)
+    X = np.random.rand(8, 5).astype(np.float32)
+    y = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    try:
+        train_cebra(X, y, cfg, Path("."))
+    except TypeError as exc:  # pragma: no cover - ensure failure message
+        assert False, f"TypeError raised: {exc}"


### PR DESCRIPTION
## Summary
- Sample positive and negative embeddings within supervised training batches and feed them into the InfoNCE loss
- Add smoke test to ensure a supervised training step runs without TypeError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689ff78b51348322b50ea0ba5bc8e00a