### PR TITLE
Pass labels into consistency check

### DIFF
--- a/main.py
+++ b/main.py
@@ -170,7 +170,7 @@ def main(cfg: AppConfig) -> None:
         # --- 7. Consistency Check ---
         if cfg.consistency_check.enabled:
             print("\n--- Step 7: Running Consistency Check ---")
-            run_consistency_check(X_train, X_valid, cfg, output_dir)
+            run_consistency_check(X_train, labels_for_training, X_valid, cfg, output_dir)
 
         print("\n--- Pipeline Complete ---")
 

--- a/src/results.py
+++ b/src/results.py
@@ -153,15 +153,22 @@ def run_knn_regression(train_embeddings, valid_embeddings, y_train, y_valid,
     
     return mse, r2
 
-def run_consistency_check(X_train, X_valid, cfg: AppConfig, output_dir: Path):
-    
+def run_consistency_check(
+    X_train,
+    y_train,
+    X_valid,
+    cfg: AppConfig,
+    output_dir: Path,
+    y_valid=None,
+):
+
     print("\n--- Step 6: Running Consistency Check ---")
     check_cfg = cfg.consistency_check
     num_runs = check_cfg.num_runs
 
     model_paths = []
     for i in tqdm(range(num_runs), desc="Training models for consistency check"):
-        model = train_cebra(X_train, None, cfg, output_dir)
+        model = train_cebra(X_train, y_train, cfg, output_dir)
         tmp_file = Path(tempfile.gettempdir(), f"cebra_consistency_{i}.pt")
         torch.save(model.state_dict(), tmp_file)
         model_paths.append(tmp_file)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,60 @@
+import numpy as np
+import mlflow
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.results import run_consistency_check
+from src.config_schema import (
+    AppConfig,
+    PathsConfig,
+    DatasetConfig,
+    EmbeddingConfig,
+    CEBRAConfig,
+    EvaluationConfig,
+    MLflowConfig,
+    ConsistencyCheckConfig,
+    VisualizationConfig,
+)
+
+def make_config() -> AppConfig:
+    cfg = AppConfig(
+        paths=PathsConfig(embedding_cache_dir=""),
+        dataset=DatasetConfig(
+            name="dummy",
+            hf_path="",
+            text_column="text",
+            label_column="label",
+            label_map={0: "a", 1: "b"},
+            visualization=VisualizationConfig(emotion_colors={}, emotion_order=[]),
+        ),
+        embedding=EmbeddingConfig(name="dummy", type="dummy", model_name="dummy"),
+        cebra=CEBRAConfig(
+            output_dim=2,
+            max_iterations=1,
+            conditional="discrete",
+            params={"batch_size": 4},
+        ),
+        evaluation=EvaluationConfig(test_size=0.2, random_state=0, knn_neighbors=1),
+        mlflow=MLflowConfig(experiment_name="", run_name=""),
+        consistency_check=ConsistencyCheckConfig(enabled=True, num_runs=2),
+    )
+    cfg.device = "cpu"
+    return cfg
+
+
+def test_consistency_check_runs_without_value_error(tmp_path):
+    cfg = make_config()
+    X_train = np.random.rand(8, 5).astype(np.float32)
+    X_valid = np.random.rand(4, 5).astype(np.float32)
+    y_train = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    mlflow.set_tracking_uri(tmp_path.as_posix())
+    mlflow.set_experiment("test-exp")
+    with mlflow.start_run():
+        try:
+            run_consistency_check(X_train, y_train, X_valid, cfg, tmp_path)
+        except ValueError as exc:
+            pytest.fail(f"Consistency check raised ValueError: {exc}")
+


### PR DESCRIPTION
## Summary
- allow consistency check to accept training labels
- pass labels from main pipeline when performing consistency check
- add test ensuring conditional consistency check runs without errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a015a5592c83228c472e96495e549d