### PR TITLE
Add configurable DataLoader performance options

### DIFF
--- a/conf/cebra/cebra7dim2.yaml
+++ b/conf/cebra/cebra7dim2.yaml
@@ -8,6 +8,10 @@ model_architecture: offset0-model
 output_dim: 2
 max_iterations: 10000
 conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
 # Nested parameters for the model
 params:
   batch_size: 512

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -36,6 +36,10 @@ class CEBRAConfig:
     # Allow arbitrary model names so new architectures can be specified
     model_architecture: str = "offset0-model"
     params: Dict[str, Any] = field(default_factory=dict)
+    num_workers: int = 0
+    pin_memory: bool = True
+    persistent_workers: bool = True
+    prefetch_factor: int = 2
 
 @dataclass
 class EvaluationConfig:


### PR DESCRIPTION
## Summary
- allow configuring DataLoader workers, memory pinning, persistence and prefetching through `cfg.cebra`
- enable non-blocking device transfers for training batches
- document new parameters in default CEBRA config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4097f83ac8322b6f7f59944d2580c