### PR TITLE
Add CEBRA dimensional optimization with GoF metric

### DIFF
--- a/src/results.py
+++ b/src/results.py
@@ -22,7 +22,7 @@ from sklearn.neighbors import KNeighborsRegressor
 from sklearn.metrics import mean_squared_error, r2_score
 import torch
 import gc
-from .cebra_trainer import train_cebra, transform_cebra, load_cebra_model
+import cebra
 # train_test_splitはこのファイルで使われていないため削除
 
 
@@ -161,6 +161,7 @@ def run_consistency_check(
     cfg: AppConfig,
     output_dir: Path,
     y_valid=None,
+    step: int | None = None,
 ):
 
     print("\n--- Step 6: Running Consistency Check ---")
@@ -173,11 +174,25 @@ def run_consistency_check(
 
     model_paths = []
     for i in tqdm(range(num_runs), desc="Training models for consistency check"):
-        model = train_cebra(X_train, y_train, cfg, output_dir)
+        arch = cfg.cebra.model_architecture
+        if arch == "offset0-model":
+            arch = "offset1-model"
+        model = cebra.CEBRA(
+            model_architecture=arch,
+            output_dimension=cfg.cebra.output_dim,
+            max_iterations=cfg.cebra.max_iterations,
+            batch_size=cfg.cebra.params.get("batch_size", 512),
+            learning_rate=cfg.cebra.params.get("learning_rate", 1e-3),
+            conditional=None if cfg.cebra.conditional == "None" else cfg.cebra.conditional,
+            device=cfg.device,
+        )
+        if y_train is None:
+            model.fit(X_train)
+        else:
+            model.fit(X_train, y_train)
         tmp_file = Path(tempfile.gettempdir(), f"cebra_consistency_{i}.pt")
-        torch.save(model.state_dict(), tmp_file)
+        model.save(str(tmp_file))
         model_paths.append(tmp_file)
-        # Release resources from this training run
         del model
         gc.collect()
         torch.cuda.empty_cache()
@@ -185,9 +200,9 @@ def run_consistency_check(
     train_embeddings = []
     valid_embeddings = []
     for tmp_file in tqdm(model_paths, desc="Transforming with saved models"):
-        loaded_model = load_cebra_model(tmp_file, cfg, X_train.shape[1])
-        train_embeddings.append(transform_cebra(loaded_model, X_train, cfg.device))
-        valid_embeddings.append(transform_cebra(loaded_model, X_valid, cfg.device))
+        loaded_model = cebra.CEBRA.load(str(tmp_file))
+        train_embeddings.append(loaded_model.transform(X_train))
+        valid_embeddings.append(loaded_model.transform(X_valid))
         tmp_file.unlink()
         del loaded_model
         gc.collect()
@@ -198,7 +213,7 @@ def run_consistency_check(
         scores, pairs, ids_runs = consistency_score(embeddings=embeddings, between="runs")
         
         mean_score = scores.mean()
-        mlflow.log_metric(f"consistency_score_{name}", mean_score)
+        mlflow.log_metric(f"consistency_score_{name}", mean_score, step=step)
         print(f"Mean consistency score ({name}): {mean_score:.4f}")
 
         ax = plot_consistency(scores, pairs, ids_runs)


### PR DESCRIPTION
## Summary
- Add `macmainoptimize.py` to train CEBRA across dimensions 2-20, log goodness-of-fit, and evaluate embeddings without PCA/UMAP baselines
- Enhance consistency checks to train via scikit-learn CEBRA and log metrics per dimension

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aa53e5cdf88322a8f46d0894d0a16d