### PR TITLE
Add configs for multiple CEBRA model architectures

### DIFF
--- a/conf/cebra/offset1-model-mse.yaml
+++ b/conf/cebra/offset1-model-mse.yaml
@@ -1,0 +1,22 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset1-model-mse
+
+model_architecture: offset1-model-mse
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  loss: mse
+  verbose: True

--- a/conf/cebra/offset1-model-v2.yaml
+++ b/conf/cebra/offset1-model-v2.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset1-model-v2
+
+model_architecture: offset1-model-v2
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/offset1-model-v3.yaml
+++ b/conf/cebra/offset1-model-v3.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset1-model-v3
+
+model_architecture: offset1-model-v3
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/offset1-model-v4.yaml
+++ b/conf/cebra/offset1-model-v4.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset1-model-v4
+
+model_architecture: offset1-model-v4
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/offset1-model-v5.yaml
+++ b/conf/cebra/offset1-model-v5.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset1-model-v5
+
+model_architecture: offset1-model-v5
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/offset1-model.yaml
+++ b/conf/cebra/offset1-model.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset1-model
+
+model_architecture: offset1-model
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/offset10-model-mse.yaml
+++ b/conf/cebra/offset10-model-mse.yaml
@@ -1,0 +1,22 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset10-model-mse
+
+model_architecture: offset10-model-mse
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  loss: mse
+  verbose: True

--- a/conf/cebra/offset10-model.yaml
+++ b/conf/cebra/offset10-model.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset10-model
+
+model_architecture: offset10-model
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/offset5-model.yaml
+++ b/conf/cebra/offset5-model.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: offset5-model
+
+model_architecture: offset5-model
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/resample-model.yaml
+++ b/conf/cebra/resample-model.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: resample-model
+
+model_architecture: resample-model
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/supervised1-model.yaml
+++ b/conf/cebra/supervised1-model.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: supervised1-model
+
+model_architecture: supervised1-model
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True

--- a/conf/cebra/supervised10-model.yaml
+++ b/conf/cebra/supervised10-model.yaml
@@ -1,0 +1,21 @@
+# @package cebra
+# A descriptive name for this configuration
+name: supervised10-model
+
+model_architecture: supervised10-model
+
+# CEBRA-specific parameters
+output_dim: 2
+max_iterations: 10000
+conditional: 'discrete'
+num_workers: 2
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2
+# Nested parameters for the model
+params:
+  batch_size: 512
+  learning_rate: 3e-4 # Higher learning rate
+  temperature: 1.0
+  distance: 'cosine' # Different distance metric
+  verbose: True


### PR DESCRIPTION
## Summary
- add YAML configs for offset, resample, and supervised CEBRA architectures
- mark `*-mse` models with `params.loss: mse`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aafaaf84fc8322927068d665233e81