### PR TITLE
Normalize model architecture handling

### DIFF
--- a/macmain.py
+++ b/macmain.py
@@ -11,7 +11,12 @@ from hydra.core.hydra_config import HydraConfig
 from src.data import load_and_prepare_dataset
 from src.utils import get_embedding_cache_path, save_text_embedding, load_text_embedding
 from src.embeddings import get_embeddings
-from src.cebra_trainer import train_cebra, save_cebra_model, transform_cebra
+from src.cebra_trainer import (
+    train_cebra,
+    save_cebra_model,
+    transform_cebra,
+    normalize_model_architecture,
+)
 from sklearn.model_selection import train_test_split
 from src.results import (save_interactive_plot, save_static_2d_plots,
                          run_knn_classification, run_knn_regression,
@@ -57,11 +62,13 @@ def main(cfg: AppConfig) -> None:
         mlflow.set_tag("hydra_run_dir", str(output_dir))
         mlflow.log_dict(OmegaConf.to_container(cfg, resolve=True), "config.yaml")
 
-        mlflow.set_tags({"cebra_model": cfg.cebra.model_architecture, "output_dim": str(cfg.cebra.output_dim) })
+        arch = normalize_model_architecture(cfg.cebra.model_architecture)
+        cfg.cebra.model_architecture = arch
+        mlflow.set_tags({"cebra_model": arch, "output_dim": str(cfg.cebra.output_dim) })
         mlflow.log_param("cebra_output_dim", cfg.cebra.output_dim)
         mlflow.log_param("cebra_max_iterations", cfg.cebra.max_iterations)
         mlflow.log_param("cebra_conditional", cfg.cebra.conditional)
-        mlflow.log_param("cebra_model_architecture", cfg.cebra.model_architecture)
+        mlflow.log_param("cebra_model_architecture", arch)
 
         # --- 1. Load Dataset ---
         print("\n--- Step 1: Loading dataset ---")

--- a/macmainoptimize.py
+++ b/macmainoptimize.py
@@ -22,6 +22,7 @@ from dotenv import load_dotenv
 import os
 from cebra.integrations.sklearn.metrics import goodness_of_fit_score
 import cebra
+from src.cebra_trainer import normalize_model_architecture
 
 load_dotenv()
 
@@ -106,9 +107,7 @@ def main(cfg: AppConfig) -> None:
 
                     # Train CEBRA model
                     print("\n--- Step 4: Training CEBRA model ---")
-                    arch = cfg.cebra.model_architecture
-                    if arch == "offset0-model":
-                        arch = "offset1-model"
+                    arch = normalize_model_architecture(cfg.cebra.model_architecture)
                     cebra_model = cebra.CEBRA(
                         model_architecture=arch,
                         output_dimension=dim,

--- a/main.py
+++ b/main.py
@@ -11,7 +11,12 @@ from hydra.core.hydra_config import HydraConfig
 from src.data import load_and_prepare_dataset
 from src.utils import get_embedding_cache_path, save_text_embedding, load_text_embedding
 from src.embeddings import get_embeddings
-from src.cebra_trainer import train_cebra, save_cebra_model, transform_cebra
+from src.cebra_trainer import (
+    train_cebra,
+    save_cebra_model,
+    transform_cebra,
+    normalize_model_architecture,
+)
 from sklearn.model_selection import train_test_split
 from src.results import (save_interactive_plot, save_static_2d_plots,
                          run_knn_classification, run_knn_regression,
@@ -60,11 +65,13 @@ def main(cfg: AppConfig) -> None:
         mlflow.set_tag("hydra_run_dir", str(output_dir))
         mlflow.log_dict(OmegaConf.to_container(cfg, resolve=True), "config.yaml")
 
-        mlflow.set_tags({"cebra_model": cfg.cebra.model_architecture, "output_dim": str(cfg.cebra.output_dim) })
+        arch = normalize_model_architecture(cfg.cebra.model_architecture)
+        cfg.cebra.model_architecture = arch
+        mlflow.set_tags({"cebra_model": arch, "output_dim": str(cfg.cebra.output_dim) })
         mlflow.log_param("cebra_output_dim", cfg.cebra.output_dim)
         mlflow.log_param("cebra_max_iterations", cfg.cebra.max_iterations)
         mlflow.log_param("cebra_conditional", cfg.cebra.conditional)
-        mlflow.log_param("cebra_model_architecture", cfg.cebra.model_architecture)
+        mlflow.log_param("cebra_model_architecture", arch)
 
         # --- 1. Load Dataset ---
         print("\n--- Step 1: Loading dataset ---")

--- a/src/cebra_trainer.py
+++ b/src/cebra_trainer.py
@@ -39,10 +39,27 @@ def save_cebra_embeddings(embeddings, output_dir):
     return path
 
 
-def _build_model(cfg: AppConfig, num_neurons: int):
+def normalize_model_architecture(name: str) -> str:
+    """Normalize and register a model architecture name.
+
+    This ensures that custom architectures such as ``offset0-model`` are
+    registered with ``cebra``'s model registry so they can be referenced by
+    the high level :class:`cebra.CEBRA` API.
+
+    Parameters
+    ----------
+    name: str
+        Requested model architecture name.
+
+    Returns
+    -------
+    str
+        Normalized architecture name that is registered in the cebra registry.
+    """
+
     import cebra, re
 
-    name = getattr(cfg.cebra, "model_architecture", "offset0-model").lower()
+    normalized = name.lower()
 
     registry = {
         "offset0-model": cebra.models.Offset0Model,
@@ -54,17 +71,30 @@ def _build_model(cfg: AppConfig, num_neurons: int):
         ),
     }
 
-    ModelClass = registry.get(name)
+    ModelClass = registry.get(normalized)
     if ModelClass is None:
-        # Attempt to dynamically resolve the model class from its name
-        parts = [p for p in re.split(r"[-_]", name) if p]
+        parts = [p for p in re.split(r"[-_]", normalized) if p]
         class_name = "".join(part.capitalize() for part in parts)
         ModelClass = getattr(cebra.models, class_name, None)
 
     if ModelClass is None:
         raise ValueError(f"Unsupported model_architecture: {name}")
 
-    return ModelClass(
+    if normalized not in cebra.models.get_options():
+        cebra.models.register(normalized, override=True, deprecated=True)(ModelClass)
+
+    return normalized
+
+
+def _build_model(cfg: AppConfig, num_neurons: int):
+    import cebra
+
+    name = normalize_model_architecture(
+        getattr(cfg.cebra, "model_architecture", "offset0-model")
+    )
+
+    return cebra.models.init(
+        name,
         num_neurons=num_neurons,
         num_units=cfg.cebra.params.get("num_units", 512),
         num_output=cfg.cebra.output_dim,

--- a/src/results.py
+++ b/src/results.py
@@ -23,6 +23,7 @@ from sklearn.metrics import mean_squared_error, r2_score
 import torch
 import gc
 import cebra
+from .cebra_trainer import normalize_model_architecture
 # train_test_splitはこのファイルで使われていないため削除
 
 
@@ -174,9 +175,7 @@ def run_consistency_check(
 
     model_paths = []
     for i in tqdm(range(num_runs), desc="Training models for consistency check"):
-        arch = cfg.cebra.model_architecture
-        if arch == "offset0-model":
-            arch = "offset1-model"
+        arch = normalize_model_architecture(cfg.cebra.model_architecture)
         model = cebra.CEBRA(
             model_architecture=arch,
             output_dimension=cfg.cebra.output_dim,


### PR DESCRIPTION
## Summary
- add normalization/registration helper for CEBRA architectures
- use normalized names throughout results and optimization scripts
- log normalized architecture names to MLflow in training scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aafab1ae548322b3e3d85b5f9c76fc