### PR TITLE
Seed randomness for reproducible Mac optimization runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ python macmain.py
 ```bash
 torchrun --nproc_per_node=2 main.py
 ```
+
+## Reproducibility
+
+`evaluation.random_state` で指定した値を用いて Python の `random`、NumPy、PyTorch (CUDA が利用可能な場合は `torch.cuda` も含む) の乱数シードを設定し、結果の再現性を高めています。

--- a/macmainoptimize.py
+++ b/macmainoptimize.py
@@ -2,6 +2,7 @@ import hydra
 import numpy as np
 from omegaconf import OmegaConf
 import torch
+import random
 import mlflow
 import pandas as pd
 from pathlib import Path
@@ -33,6 +34,11 @@ def main(cfg: AppConfig) -> None:
     cfg.ddp.rank = 0
     cfg.ddp.local_rank = 0
     cfg.device = "mps" if torch.backends.mps.is_available() else "cpu"
+    random.seed(cfg.evaluation.random_state)
+    np.random.seed(cfg.evaluation.random_state)
+    torch.manual_seed(cfg.evaluation.random_state)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(cfg.evaluation.random_state)
     output_dir = Path(HydraConfig.get().run.dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Seed Python, NumPy, and PyTorch (including CUDA) at the start of `macmainoptimize.py` using `evaluation.random_state`
- Document the seeding behavior in the README for clearer reproducibility guidance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab03367a5c8322b3baba5708454a6b