### PR TITLE
Enable CUDA and MPS device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@
 python main.py
 ```
 
-Mac (CPU/MPS) での実行:
+Mac (CUDA/MPS/CPU) での実行 (自動デバイス検出):
 
 ```bash
 python macmain.py
+# or
+python macmainoptimize.py
 ```
 
 分散学習 (2 GPU) での実行例:

--- a/macmainoptimize.py
+++ b/macmainoptimize.py
@@ -32,7 +32,13 @@ def main(cfg: AppConfig) -> None:
     cfg.ddp.world_size = 1
     cfg.ddp.rank = 0
     cfg.ddp.local_rank = 0
-    cfg.device = "mps" if torch.backends.mps.is_available() else "cpu"
+    # Select the best available device
+    if torch.cuda.is_available():
+        cfg.device = "cuda"
+    elif torch.backends.mps.is_available():
+        cfg.device = "mps"
+    else:
+        cfg.device = "cpu"
     output_dir = Path(HydraConfig.get().run.dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- select CUDA when available, fall back to MPS or CPU
- document automatic device detection in Mac entrypoints

## Testing
- `python - <<'PY'
import torch
if torch.cuda.is_available():
    device = "cuda"
elif torch.backends.mps.is_available():
    device = "mps"
else:
    device = "cpu"
print("Detected device:", device)
orig_cuda = torch.cuda.is_available
orig_mps = torch.backends.mps.is_available
torch.cuda.is_available = lambda: True
torch.backends.mps.is_available = lambda: False
if torch.cuda.is_available():
    device = "cuda"
elif torch.backends.mps.is_available():
    device = "mps"
else:
    device = "cpu"
print("Simulated CUDA device:", device)
torch.cuda.is_available = orig_cuda
torch.backends.mps.is_available = orig_mps
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab03358a908322a98e70f48a540350