### PR TITLE
Add Offset1ModelMSE architecture mapping

### DIFF
--- a/src/cebra_trainer.py
+++ b/src/cebra_trainer.py
@@ -66,6 +66,7 @@ def normalize_model_architecture(name: str) -> str:
     registry = {
         "offset0-model": cebra.models.Offset0Model,
         "offset1-model": default_model,
+        "offset1-model-mse": getattr(cebra.models, "Offset1ModelMSE", default_model),
         "offset5-model": getattr(cebra.models, "Offset5Model", default_model),
         "offset10-model": getattr(cebra.models, "Offset10Model", default_model),
         "offset10-model-mse": getattr(


### PR DESCRIPTION
## Summary
- support `offset1-model-mse` in `normalize_model_architecture`
- ensure normalized model names are registered and returned to avoid configuration errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab1cc7b5508322b117eaa946a009bc