### PR TITLE
Support acronym normalization in model architecture names

### DIFF
--- a/src/cebra_trainer.py
+++ b/src/cebra_trainer.py
@@ -68,9 +68,6 @@ def normalize_model_architecture(name: str) -> str:
         "offset1-model": default_model,
         "offset5-model": getattr(cebra.models, "Offset5Model", default_model),
         "offset10-model": getattr(cebra.models, "Offset10Model", default_model),
-        "offset10-model-mse": getattr(
-            cebra.models, "Offset10ModelMSE", default_model
-        ),
         "offset36-model": getattr(cebra.models, "Offset36", default_model),
         "offset36-dropout": getattr(
             cebra.models, "Offset36Dropout", default_model
@@ -92,7 +89,10 @@ def normalize_model_architecture(name: str) -> str:
     ModelClass = registry.get(normalized)
     if ModelClass is None:
         parts = [p for p in re.split(r"[-_]", normalized) if p]
-        class_name = "".join(part.capitalize() for part in parts)
+        acronyms = {"mse"}
+        class_name = "".join(
+            part.upper() if part in acronyms else part.capitalize() for part in parts
+        )
         ModelClass = getattr(cebra.models, class_name, None)
 
     if ModelClass is None:

--- a/tests/test_cebra_trainer.py
+++ b/tests/test_cebra_trainer.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from src.cebra_trainer import train_cebra
+from src.cebra_trainer import train_cebra, normalize_model_architecture
 from src.config_schema import (
     AppConfig,
     PathsConfig,
@@ -48,6 +48,32 @@ def make_config(batch_size: int, loss: str = "infonce") -> AppConfig:
     )
     cfg.device = "cpu"
     return cfg
+
+
+def test_normalize_model_architecture_acronym(monkeypatch):
+    import cebra
+
+    # Provide a model class matching the expected acronym expansion.
+    monkeypatch.setattr(
+        cebra.models, "Offset1ModelMSE", cebra.models.Offset0Model, raising=False
+    )
+
+    registered = {}
+
+    def fake_register(name, override=True, deprecated=True):
+        def decorator(cls):
+            registered[name] = cls
+            return cls
+
+        return decorator
+
+    monkeypatch.setattr(cebra.models, "register", fake_register)
+    monkeypatch.setattr(cebra.models, "get_options", lambda: [])
+
+    normalized = normalize_model_architecture("offset1-model-mse")
+
+    assert normalized == "offset1-model-mse"
+    assert registered["offset1-model-mse"] is cebra.models.Offset0Model
 
 
 def test_train_one_step_no_type_error():


### PR DESCRIPTION
## Summary
- Normalize model architecture names by uppercasing known acronyms such as `mse`
- Resolve architectures like `offset1-model-mse` without manual registry entries
- Add tests ensuring acronym normalization and model registration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab1cc8920c83229efb09b90fccfc36