### PR TITLE
Add Kaggle dataset configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ torchrun --nproc_per_node=2 main.py
 python main.py -m hpt=my_sweep
 ```
 
+### Kaggle データセットを使用する
+
+Kaggle の階層型テキスト分類データセットを利用する場合は、データを
+`data/kaggle/hierarchical-text-classification` に配置し、
+以下のようにデータセット設定を切り替えます:
+
+```bash
+python main.py dataset=hierarchical_text_classification
+```
+
+`conf/paths/default.yaml` の `kaggle_data_dir` を変更することで、データの
+保存場所をカスタマイズできます。
+
 ## Experiment Tracking
 
 This project uses [Weights & Biases](https://wandb.ai/) for experiment tracking.

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,5 +1,6 @@
 # デフォルトで読み込む設定グループを指定
 defaults:
+  - paths: default
   - dataset: dair-ai
   - embedding: bert
   - cebra: cebra7dim2

--- a/conf/dataset/hierarchical_text_classification.yaml
+++ b/conf/dataset/hierarchical_text_classification.yaml
@@ -1,0 +1,13 @@
+# @package dataset
+name: hierarchical_text_classification
+source: kaggle
+data_files: train.csv
+text_column: text
+label_column: label
+label_map:
+  0: "business"
+  1: "entertainment"
+  2: "politics"
+  3: "sport"
+  4: "tech"
+

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -1,3 +1,5 @@
 # conf/paths/default.yaml
 
 embedding_cache_dir: "embedding_cache"
+kaggle_data_dir: "data/kaggle/hierarchical-text-classification"
+

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -11,11 +11,13 @@ class VisualizationConfig:
 @dataclass
 class DatasetConfig:
     name: str
-    hf_path: str
     text_column: str
     label_column: str
     label_map: Dict[int, str]
     visualization: VisualizationConfig
+    hf_path: Optional[str] = None
+    source: Literal["hf", "csv", "kaggle"] = "hf"
+    data_files: Optional[str] = None
 
 @dataclass
 class EmbeddingConfig:
@@ -62,6 +64,7 @@ class DDPConfig:
 @dataclass
 class PathsConfig:
     embedding_cache_dir: str
+    kaggle_data_dir: str = "data/kaggle/hierarchical-text-classification"
 
 @dataclass
 class ConsistencyCheckConfig:

--- a/src/data.py
+++ b/src/data.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 import numpy as np
 from datasets import load_dataset
@@ -9,7 +10,16 @@ def load_and_prepare_dataset(cfg: AppConfig):
     """
     dataset_cfg = cfg.dataset
     print(f"Loading dataset: {dataset_cfg.name}")
-    dataset = load_dataset(dataset_cfg.hf_path)
+
+    if dataset_cfg.source == "hf":
+        dataset = load_dataset(dataset_cfg.hf_path)
+    elif dataset_cfg.source == "csv":
+        dataset = load_dataset("csv", data_files=dataset_cfg.data_files)
+    elif dataset_cfg.source == "kaggle":
+        data_path = os.path.join(cfg.paths.kaggle_data_dir, dataset_cfg.data_files)
+        dataset = load_dataset("csv", data_files=data_path)
+    else:
+        raise ValueError(f"Unsupported dataset source: {dataset_cfg.source}")
 
     # Combine all splits for a comprehensive analysis
     all_splits = [pd.DataFrame(dataset[split]) for split in dataset.keys()]


### PR DESCRIPTION
## Summary
- load path settings by default
- support Kaggle datasets with new schema fields and loader logic
- document and configure hierarchical text classification dataset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68adca9477948322bf2d8ecf064b665f