### PR TITLE
chore: remove aws secrets from config

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -22,12 +22,12 @@ wandb:
   project: "CEBRA_NLP_Experiment"
   run_name: "default_run"
   entity: null
-secrets:
-  aws_access_key_id: ${oc.env:AWS_ACCESS_KEY_ID}
-  aws_secret_access_key: ${oc.env:AWS_SECRET_ACCESS_KEY}
-  endpoint_url: ${oc.env:MLFLOW_S3_ENDPOINT_URL, http://localhost:9000}
-  region: ${oc.env:AWS_DEFAULT_REGION, us-east-1}
-  s3_signature_version: ${oc.env:AWS_S3_SIGNATURE_VERSION, s3v4}
+# secrets:
+#   aws_access_key_id: ${oc.env:AWS_ACCESS_KEY_ID}
+#   aws_secret_access_key: ${oc.env:AWS_SECRET_ACCESS_KEY}
+#   endpoint_url: ${oc.env:MLFLOW_S3_ENDPOINT_URL, http://localhost:9000}
+#   region: ${oc.env:AWS_DEFAULT_REGION, us-east-1}
+#   s3_signature_version: ${oc.env:AWS_S3_SIGNATURE_VERSION, s3v4}
 ddp:
   world_size: 1
   rank: 0


### PR DESCRIPTION
## Summary
- comment out AWS-related secrets in config
- leave Weights & Biases setup intact for offline mode

## Testing
- `pytest -q`
- `WANDB_MODE=offline torchrun --standalone --nproc_per_node=1 main.py cebra.max_iterations=1 evaluation.test_size=0.99` *(fails: ProcessGroupNCCL is only supported with GPUs, no GPUs found!)*

------
https://chatgpt.com/codex/tasks/task_b_68ae67841dd483229d83efe56612dea2