### PR TITLE
Add HuggingFace source to dataset configs

### DIFF
--- a/conf/dataset/dair-ai.yaml
+++ b/conf/dataset/dair-ai.yaml
@@ -1,5 +1,6 @@
 # @package dataset
 name: dair-ai
+source: hf
 hf_path: "dair-ai/emotion"
 text_column: "text"
 label_column: "label"

--- a/conf/dataset/go_emotions.yaml
+++ b/conf/dataset/go_emotions.yaml
@@ -1,6 +1,7 @@
 # @package dataset
 
 name: go_emotions
+source: hf
 hf_path: "go_emotions"
 text_column: "text"
 label_column: "labels"


### PR DESCRIPTION
## Summary
- specify HuggingFace as the data source for the dair-ai dataset
- specify HuggingFace as the data source for the go_emotions dataset

## Testing
- `torchrun --nproc_per_node=1 main.py` *(fails: ProcessGroupNCCL is only supported with GPUs, no GPUs found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae9058642883228c081769d1c13505