### PR TITLE
Add dataset source default and validation

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -16,7 +16,7 @@ class DatasetConfig:
     label_map: Dict[int, str]
     visualization: VisualizationConfig
     hf_path: Optional[str] = None
-    source: Literal["hf", "csv", "kaggle"] = "hf"
+    source: Optional[Literal["hf", "csv", "kaggle"]] = "hf"
     data_files: Optional[str] = None
 
 @dataclass

--- a/src/data.py
+++ b/src/data.py
@@ -11,6 +11,11 @@ def load_and_prepare_dataset(cfg: AppConfig):
     dataset_cfg = cfg.dataset
     print(f"Loading dataset: {dataset_cfg.name}")
 
+    if dataset_cfg.source is None:
+        raise ValueError(
+            "Dataset source is not specified. Supported sources are 'hf', 'csv', and 'kaggle'."
+        )
+
     if dataset_cfg.source == "hf":
         dataset = load_dataset(dataset_cfg.hf_path)
     elif dataset_cfg.source == "csv":
@@ -19,7 +24,9 @@ def load_and_prepare_dataset(cfg: AppConfig):
         data_path = os.path.join(cfg.paths.kaggle_data_dir, dataset_cfg.data_files)
         dataset = load_dataset("csv", data_files=data_path)
     else:
-        raise ValueError(f"Unsupported dataset source: {dataset_cfg.source}")
+        raise ValueError(
+            f"Unsupported dataset source: {dataset_cfg.source}. Supported sources are 'hf', 'csv', and 'kaggle'."
+        )
 
     # Combine all splits for a comprehensive analysis
     all_splits = [pd.DataFrame(dataset[split]) for split in dataset.keys()]


### PR DESCRIPTION
## Summary
- default dataset source to `"hf"` in configuration
- validate dataset source and raise descriptive errors for missing/unsupported values

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68ae925021748322b1d563abf3de7b31