### PR TITLE
refactor: remove unused AppConfig imports

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -2,9 +2,12 @@ import os
 import pandas as pd
 import numpy as np
 from datasets import load_dataset
-from src.config_schema import AppConfig # ← この行を追加
+from typing import TYPE_CHECKING
 
-def load_and_prepare_dataset(cfg: AppConfig):
+if TYPE_CHECKING:
+    from src.config_schema import AppConfig
+
+def load_and_prepare_dataset(cfg: "AppConfig"):
     """
     Loads the dataset specified in the config, prepares texts and labels.
     """

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -1,7 +1,10 @@
 import numpy as np
 import torch
 from tqdm import tqdm
-from src.config_schema import AppConfig # ← この行を追加
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.config_schema import AppConfig
 
 def get_hf_transformer_embeddings(texts, model_name, device):
     """Generates embeddings using a standard Hugging Face Transformer (BERT, RoBERTa)."""
@@ -53,7 +56,7 @@ def get_word2vec_embeddings(texts, w2v_params):
             
     return np.vstack(sentence_embeddings)
 
-def get_embeddings(texts: list, cfg: AppConfig) -> np.ndarray:
+def get_embeddings(texts: list, cfg: "AppConfig") -> np.ndarray:
     """Factory function to select and run the appropriate embedding model."""
     emb_cfg = cfg.embedding
     print(f"\n--- Generating embeddings using model: {emb_cfg.name} ---")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import numpy as np
 from omegaconf import OmegaConf
-from src.config_schema import AppConfig # ← この行を追加
 
 def get_embedding_cache_path(cfg):
     """


### PR DESCRIPTION
## Summary
- remove stale AppConfig import and stray comment in utils
- wrap AppConfig type hints in TYPE_CHECKING blocks for embeddings and data
- strip leftover Japanese inline comments

## Testing
- `ruff check .` *(fails: unrecognized for some environment? Wait we used `ruff check .` and there are errors, but we mention run but fails? instructions: we must not misrepresent; we run ruff check . and it produced lint errors but not due to touched files; but we may mention we ran linter for entire repo with failing due to existing issues, but our files pass; we also ran ruff check on specific files.*
- `ruff check src/utils.py src/embeddings.py src/data.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae94f1bd40832289559de557bd6767