### PR TITLE
Normalize conditional mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ python main.py dataset=hierarchical_text_classification
 `conf/paths/default.yaml` の `kaggle_data_dir` を変更することで、データの
 保存場所をカスタマイズできます。
 
+## Conditional Modes
+
+`cebra.conditional` はラベルの条件付け方法を指定します。利用可能なモードは以下のとおりです。
+
+- `none`: 条件付けなし
+- `discrete`: 離散ラベルを使用
+- `custom`: 任意の条件データを使用
+
+値は大文字小文字を区別しません。
+
 ## Experiment Tracking
 
 This project uses [Weights & Biases](https://wandb.ai/) for experiment tracking.

--- a/conf/cebra/cebra7dim3.1.yaml
+++ b/conf/cebra/cebra7dim3.1.yaml
@@ -7,7 +7,7 @@ model_architecture: offset1-model
 # CEBRA-specific parameters
 output_dim: 3
 max_iterations: 10000
-conditional: 'None'
+conditional: 'none'
 # Nested parameters for the model
 params:
   batch_size: 512

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ load_dotenv()
 @hydra.main(config_path="conf", config_name="config", version_base="1.2")
 def main(cfg: AppConfig) -> None:
     OmegaConf.set_struct(cfg, False)
+    cfg.cebra.conditional = cfg.cebra.conditional.lower()
     local_rank = int(os.environ["LOCAL_RANK"])
     cfg.ddp.world_size = int(os.environ.get("WORLD_SIZE", 1))
     cfg.ddp.rank = int(os.environ.get("RANK", 0))
@@ -69,7 +70,7 @@ def main(cfg: AppConfig) -> None:
     # --- 1. Load Dataset ---
     print("\n--- Step 1: Loading dataset ---")
     # 'conditional_data' という変数名に統一
-    if cfg.cebra.conditional == 'None':
+    if cfg.cebra.conditional == 'none':
         dataset_cfg = cfg.dataset
         # データセットのソースに応じて読み込み
         source = getattr(dataset_cfg, "source", "hf")
@@ -118,7 +119,7 @@ def main(cfg: AppConfig) -> None:
     print("\n--- Step 4: Training CEBRA model ---")
 
     labels_for_training = (
-        None if cfg.cebra.conditional == "None" else conditional_train
+        None if cfg.cebra.conditional == "none" else conditional_train
     )
     cebra_model = train_cebra(X_train, labels_for_training, cfg, output_dir)
     model_path = save_cebra_model(cebra_model, output_dir)
@@ -170,7 +171,7 @@ def main(cfg: AppConfig) -> None:
         report_artifact.add_file(str(report_path))
         wandb.log_artifact(report_artifact)
 
-    elif cfg.cebra.conditional == 'None':
+    elif cfg.cebra.conditional == 'none':
         # [None CASE]
         print("Running None evaluation and visualization...")
         

--- a/src/cebra_trainer.py
+++ b/src/cebra_trainer.py
@@ -159,6 +159,7 @@ def train_cebra(X_vectors, labels, cfg: AppConfig, output_dir):
     from torch.utils.data import DataLoader, TensorDataset, DistributedSampler
     import inspect
 
+    cfg.cebra.conditional = cfg.cebra.conditional.lower()
     loss_type = cfg.cebra.params.get("loss", "infonce").lower()
 
     if X_vectors is None:

--- a/src/results.py
+++ b/src/results.py
@@ -188,7 +188,7 @@ def run_consistency_check(
             max_iterations=cfg.cebra.max_iterations,
             batch_size=cfg.cebra.params.get("batch_size", 512),
             learning_rate=cfg.cebra.params.get("learning_rate", 1e-3),
-            conditional=None if cfg.cebra.conditional == "None" else cfg.cebra.conditional,
+            conditional=None if cfg.cebra.conditional == "none" else cfg.cebra.conditional,
             device=cfg.device,
         )
         if y_train is None:


### PR DESCRIPTION
## Summary
- normalize `cfg.cebra.conditional` to lowercase in training pipeline
- treat conditional modes using lowercase literals (none, discrete)
- document supported conditional modes and fix config value casing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_b_68ae94f0bba483228b9a876883f9de77