### PR TITLE
Fix TYPE_CHECKING import in embeddings

### DIFF
--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -7,7 +7,7 @@ from src.config_schema import AppConfig  # ← この行を追加
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from src.config_schema import AppConfi
+    from src.config_schema import AppConfig
 
 def get_hf_transformer_embeddings(texts, model_name, device):
     """Generates embeddings using a standard Hugging Face Transformer (BERT, RoBERTa)."""


### PR DESCRIPTION
## Summary
- Restore full `AppConfig` import within TYPE_CHECKING block of `embeddings.py`

## Testing
- `pytest -q` *(fails: KeyboardInterrupt; no tests executed)*

------
https://chatgpt.com/codex/tasks/task_b_68ae999515c88322837d0afb1269fc77