### PR TITLE
chore: remove leftover arrow comments

### DIFF
--- a/macmain.py
+++ b/macmain.py
@@ -3,9 +3,9 @@ import numpy as np
 from omegaconf import OmegaConf
 import torch
 import wandb
-import pandas as pd # ← 追加
+import pandas as pd
 from pathlib import Path
-from datasets import load_dataset # ← 追加
+from datasets import load_dataset
 from src.config_schema import AppConfig
 from hydra.core.hydra_config import HydraConfig
 from src.data import load_and_prepare_dataset

--- a/main.py
+++ b/main.py
@@ -3,9 +3,9 @@ import numpy as np
 from omegaconf import OmegaConf
 import torch
 import wandb
-import pandas as pd # ← 追加
+import pandas as pd
 from pathlib import Path
-from datasets import load_dataset # ← 追加
+from datasets import load_dataset
 from src.config_schema import AppConfig
 from hydra.core.hydra_config import HydraConfig
 from src.data import load_and_prepare_dataset

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any, Optional, Literal
 @dataclass
 class VisualizationConfig:
     emotion_colors: Dict[str, str]
-    emotion_order: List[str] # ← この行を追加
+    emotion_order: List[str]
 
 @dataclass
 class DatasetConfig:

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -2,7 +2,7 @@ import numpy as np
 import torch
 from tqdm import tqdm
 
-from src.config_schema import AppConfig  # ← この行を追加
+from src.config_schema import AppConfig
 
 from typing import TYPE_CHECKING
 

--- a/src/results.py
+++ b/src/results.py
@@ -1,7 +1,7 @@
 # results.py
 import matplotlib
 
-matplotlib.use("Agg")  # ← この2行をファイルの先頭に追加
+matplotlib.use("Agg")  # Use Agg backend for headless environments
 
 
 import pandas as pd


### PR DESCRIPTION
## Summary
- remove arrow-style comments from config, embeddings, results, and training scripts
- clarify matplotlib backend comment in results module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ae9997f048832280b49ce0abbb0b04