### PR TITLE
Infer output_dim from labels for MSE loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ python main.py dataset=hierarchical_text_classification
 
 MSE 損失を使用する場合、ラベルは `cebra.output_dim` と同じ次元を持つ
 ベクトルである必要があります。整数ラベルを与えた場合は自動的に
-ワンホットベクトルに変換されますが、次元が一致しない場合はエラーと
-なります。
+ワンホットベクトルに変換されます。ラベルの最大値からクラス数を自動
+推定し (`num_classes = int(labels.max()) + 1`)、`cebra.output_dim` が一致
+しない場合は警告とともにこの値に更新されます。
 
 ## Experiment Tracking
 

--- a/conf/cebra/offset1-model-mse.yaml
+++ b/conf/cebra/offset1-model-mse.yaml
@@ -5,7 +5,7 @@ name: offset1-model-mse
 model_architecture: offset1-model-mse
 
 # CEBRA-specific parameters
-output_dim: 2
+output_dim: 2  # will be adjusted to match the number of classes
 max_iterations: 10000
 conditional: 'discrete'
 num_workers: 2

--- a/conf/cebra/offset10-model-mse.yaml
+++ b/conf/cebra/offset10-model-mse.yaml
@@ -5,7 +5,7 @@ name: offset10-model-mse
 model_architecture: offset10-model-mse
 
 # CEBRA-specific parameters
-output_dim: 2
+output_dim: 2  # will be adjusted to match the number of classes
 max_iterations: 10000
 conditional: 'discrete'
 num_workers: 2

--- a/src/cebra_trainer.py
+++ b/src/cebra_trainer.py
@@ -5,6 +5,7 @@ from src.config_schema import AppConfig
 from tqdm.auto import tqdm
 from collections import deque
 import wandb
+import warnings
 
 def get_cebra_config_hash(cfg):
     import json, hashlib
@@ -184,17 +185,20 @@ def train_cebra(X_vectors, labels, cfg: AppConfig, output_dir):
                     )
                 num_classes = int(labels.max()) + 1
                 if num_classes != cfg.cebra.output_dim:
-                    raise ValueError(
-                        "MSE loss with integer labels requires "
-                        f"cfg.cebra.output_dim={num_classes}, got {cfg.cebra.output_dim}"
+                    warnings.warn(
+                        "Adjusting cfg.cebra.output_dim from "
+                        f"{cfg.cebra.output_dim} to {num_classes} based on labels"
                     )
+                    cfg.cebra.output_dim = num_classes
                 labels = np.eye(cfg.cebra.output_dim, dtype=np.float32)[labels]
             elif labels.ndim == 2:
-                if labels.shape[1] != cfg.cebra.output_dim:
-                    raise ValueError(
-                        "MSE loss requires label vectors with dimension "
-                        f"{cfg.cebra.output_dim}, got {labels.shape[1]}"
+                num_classes = labels.shape[1]
+                if num_classes != cfg.cebra.output_dim:
+                    warnings.warn(
+                        "Adjusting cfg.cebra.output_dim from "
+                        f"{cfg.cebra.output_dim} to {num_classes} based on labels"
                     )
+                    cfg.cebra.output_dim = num_classes
             else:
                 raise ValueError("`labels` must be 1D or 2D for MSE loss")
             labels = labels.astype(np.float32)

--- a/tests/test_cebra_trainer.py
+++ b/tests/test_cebra_trainer.py
@@ -105,8 +105,8 @@ def test_mse_integer_labels_output_dim_mismatch():
     cfg = make_config(batch_size=4, loss="mse")
     X = np.random.rand(4, 5).astype(np.float32)
     y = np.array([0, 1, 2, 1])
-    with pytest.raises(ValueError):
-        train_cebra(X, y, cfg, Path("."))
+    train_cebra(X, y, cfg, Path("."))
+    assert cfg.cebra.output_dim == 3
 
 
 def test_classifier_model_tuple_output(monkeypatch):


### PR DESCRIPTION
## Summary
- infer number of classes from MSE labels and adjust `cebra.output_dim` with a warning
- document automatic output_dim adjustment in README and MSE config examples
- update tests for new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae99988728832289043037af88442b