### PR TITLE
Check plot output before logging artifacts

### DIFF
--- a/macmain.py
+++ b/macmain.py
@@ -140,10 +140,20 @@ def main(cfg: AppConfig) -> None:
 
         # 可視化
         interactive_path = output_dir / "cebra_interactive_discrete.html"
-        save_interactive_plot(cebra_embeddings_full, text_labels_full, cfg.cebra.output_dim, palette, "Interactive CEBRA (Discrete)", interactive_path)
-        vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-        vis_artifact.add_file(str(interactive_path))
-        wandb.log_artifact(vis_artifact)
+        save_interactive_plot(
+            cebra_embeddings_full,
+            text_labels_full,
+            cfg.cebra.output_dim,
+            palette,
+            "Interactive CEBRA (Discrete)",
+            interactive_path,
+        )
+        if interactive_path.exists():
+            vis_artifact = wandb.Artifact(
+                name=interactive_path.stem, type="evaluation"
+            )
+            vis_artifact.add_file(str(interactive_path))
+            wandb.log_artifact(vis_artifact)
         save_static_2d_plots(cebra_embeddings_full, text_labels_full, palette, "CEBRA Embeddings (Discrete)", output_dir, order)
         static_artifact = wandb.Artifact("cebra-static-plots", type="evaluation")
         static_artifact.add_file(str(output_dir / "static_PCA_plot.png"))
@@ -176,9 +186,12 @@ def main(cfg: AppConfig) -> None:
             title="Interactive CEBRA (None - Colored by Valence)",
             output_path=interactive_path
         )
-        vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-        vis_artifact.add_file(str(interactive_path))
-        wandb.log_artifact(vis_artifact)
+        if interactive_path.exists():
+            vis_artifact = wandb.Artifact(
+                name=interactive_path.stem, type="evaluation"
+            )
+            vis_artifact.add_file(str(interactive_path))
+            wandb.log_artifact(vis_artifact)
         # 注意: 連続値の場合、カテゴリ別の静的プロットはそのままでは適用できない
 
         # 評価

--- a/macmainoptimize.py
+++ b/macmainoptimize.py
@@ -151,9 +151,12 @@ def main(cfg: AppConfig) -> None:
                                 "Interactive CEBRA (Discrete)",
                                 interactive_path,
                             )
-                            vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-                            vis_artifact.add_file(str(interactive_path))
-                            wandb.log_artifact(vis_artifact)
+                            if interactive_path.exists():
+                                vis_artifact = wandb.Artifact(
+                                    name=interactive_path.stem, type="evaluation"
+                                )
+                                vis_artifact.add_file(str(interactive_path))
+                                wandb.log_artifact(vis_artifact)
                             accuracy, report = run_knn_classification(
                                 train_embeddings=cebra_train_embeddings,
                                 valid_embeddings=cebra_valid_embeddings,
@@ -180,9 +183,12 @@ def main(cfg: AppConfig) -> None:
                                 title="Interactive CEBRA (None - Colored by Valence)",
                                 output_path=interactive_path,
                             )
-                            vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-                            vis_artifact.add_file(str(interactive_path))
-                            wandb.log_artifact(vis_artifact)
+                            if interactive_path.exists():
+                                vis_artifact = wandb.Artifact(
+                                    name=interactive_path.stem, type="evaluation"
+                                )
+                                vis_artifact.add_file(str(interactive_path))
+                                wandb.log_artifact(vis_artifact)
                             mse, r2 = run_knn_regression(
                                 train_embeddings=cebra_train_embeddings,
                                 valid_embeddings=cebra_valid_embeddings,

--- a/macmainoptuna.py
+++ b/macmainoptuna.py
@@ -154,9 +154,12 @@ def main(cfg: AppConfig) -> None:
                         "Interactive CEBRA (Discrete)",
                         interactive_path,
                     )
-                    vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-                    vis_artifact.add_file(str(interactive_path))
-                    wandb.log_artifact(vis_artifact)
+                    if interactive_path.exists():
+                        vis_artifact = wandb.Artifact(
+                            name=interactive_path.stem, type="evaluation"
+                        )
+                        vis_artifact.add_file(str(interactive_path))
+                        wandb.log_artifact(vis_artifact)
                     accuracy, report = run_knn_classification(
                         train_embeddings=cebra_train_embeddings,
                         valid_embeddings=cebra_valid_embeddings,
@@ -183,9 +186,12 @@ def main(cfg: AppConfig) -> None:
                         title="Interactive CEBRA (None - Colored by Valence)",
                         output_path=interactive_path,
                     )
-                    vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-                    vis_artifact.add_file(str(interactive_path))
-                    wandb.log_artifact(vis_artifact)
+                    if interactive_path.exists():
+                        vis_artifact = wandb.Artifact(
+                            name=interactive_path.stem, type="evaluation"
+                        )
+                        vis_artifact.add_file(str(interactive_path))
+                        wandb.log_artifact(vis_artifact)
                     mse, r2 = run_knn_regression(
                         train_embeddings=cebra_train_embeddings,
                         valid_embeddings=cebra_valid_embeddings,

--- a/main.py
+++ b/main.py
@@ -155,10 +155,20 @@ def main(cfg: AppConfig) -> None:
 
         # 可視化
         interactive_path = output_dir / "cebra_interactive_discrete.html"
-        save_interactive_plot(cebra_embeddings_full, text_labels_full, cfg.cebra.output_dim, palette, "Interactive CEBRA (Discrete)", interactive_path)
-        vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-        vis_artifact.add_file(str(interactive_path))
-        wandb.log_artifact(vis_artifact)
+        save_interactive_plot(
+            cebra_embeddings_full,
+            text_labels_full,
+            cfg.cebra.output_dim,
+            palette,
+            "Interactive CEBRA (Discrete)",
+            interactive_path,
+        )
+        if interactive_path.exists():
+            vis_artifact = wandb.Artifact(
+                name=interactive_path.stem, type="evaluation"
+            )
+            vis_artifact.add_file(str(interactive_path))
+            wandb.log_artifact(vis_artifact)
         save_static_2d_plots(cebra_embeddings_full, text_labels_full, palette, "CEBRA Embeddings (Discrete)", output_dir, order)
         static_artifact = wandb.Artifact("cebra-static-plots", type="evaluation")
         static_artifact.add_file(str(output_dir / "static_PCA_plot.png"))
@@ -191,9 +201,12 @@ def main(cfg: AppConfig) -> None:
             title="Interactive CEBRA (None - Colored by Valence)",
             output_path=interactive_path
         )
-        vis_artifact = wandb.Artifact(name=interactive_path.stem, type="evaluation")
-        vis_artifact.add_file(str(interactive_path))
-        wandb.log_artifact(vis_artifact)
+        if interactive_path.exists():
+            vis_artifact = wandb.Artifact(
+                name=interactive_path.stem, type="evaluation"
+            )
+            vis_artifact.add_file(str(interactive_path))
+            wandb.log_artifact(vis_artifact)
         # 注意: 連続値の場合、カテゴリ別の静的プロットはそのままでは適用できない
 
         # 評価


### PR DESCRIPTION
## Summary
- ensure wandb artifacts for interactive plots are only logged when the HTML file exists
- apply the same check across all scripts that generate interactive plots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aebbefdb3883228d2cdb389760486d