### PR TITLE
Add enable_plots option to evaluation config

### DIFF
--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -48,6 +48,7 @@ class EvaluationConfig:
     test_size: float
     random_state: int
     knn_neighbors: int
+    enable_plots: bool = True
 
 @dataclass
 class WandBConfig:


### PR DESCRIPTION
## Summary
- allow evaluation config to toggle plot generation via `enable_plots`

## Testing
- `pytest tests/test_results.py::test_consistency_check_runs_without_value_error -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68b03d9df7848322a0e9f9cf30630909