### PR TITLE
Add optional plot control to kNN classification

### DIFF
--- a/src/results.py
+++ b/src/results.py
@@ -152,6 +152,7 @@ def run_knn_classification(
     label_map,
     output_dir: Path,
     knn_neighbors,
+    enable_plots=True,
 ):
     """k-NN classification for discrete labels."""
     print("\nRunning k-NN Classification evaluation...")
@@ -171,22 +172,23 @@ def run_knn_classification(
     print(f"k-NN Accuracy on Validation Set: {accuracy:.4f}")
 
     # --- Confusion Matrix ---
-    cm_plot_file = output_dir / "confusion_matrix.png"
-    fig, ax = plt.subplots(figsize=(10, 8))
-    ConfusionMatrixDisplay.from_estimator(
-        knn,
-        valid_embeddings,
-        y_valid,
-        display_labels=list(label_map.values()),
-        cmap=plt.cm.Blues,
-        ax=ax,
-        xticks_rotation="vertical",
-    )
-    ax.set_title(f"Confusion Matrix (k-NN={knn_neighbors})")
-    plt.tight_layout()
-    plt.savefig(cm_plot_file)
-    plt.close(fig)
-    print(f"Saved confusion matrix to {cm_plot_file}")
+    if enable_plots:
+        cm_plot_file = output_dir / "confusion_matrix.png"
+        fig, ax = plt.subplots(figsize=(10, 8))
+        ConfusionMatrixDisplay.from_estimator(
+            knn,
+            valid_embeddings,
+            y_valid,
+            display_labels=list(label_map.values()),
+            cmap=plt.cm.Blues,
+            ax=ax,
+            xticks_rotation="vertical",
+        )
+        ax.set_title(f"Confusion Matrix (k-NN={knn_neighbors})")
+        plt.tight_layout()
+        plt.savefig(cm_plot_file)
+        plt.close(fig)
+        print(f"Saved confusion matrix to {cm_plot_file}")
 
     return accuracy, report
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from src.results import run_consistency_check
+from src.results import run_consistency_check, run_knn_classification
 from src.config_schema import (
     AppConfig,
     PathsConfig,
@@ -61,4 +61,25 @@ def test_consistency_check_runs_without_value_error(tmp_path):
             run_consistency_check(X_train, y_train, X_valid, cfg, tmp_path)
         except ValueError as exc:
             pytest.fail(f"Consistency check raised ValueError: {exc}")
+
+
+def test_knn_classification_skips_plots(tmp_path):
+    train_embeddings = np.random.rand(8, 2)
+    valid_embeddings = np.random.rand(4, 2)
+    y_train = np.array([0, 0, 0, 0, 1, 1, 1, 1])
+    y_valid = np.array([0, 1, 0, 1])
+    label_map = {0: "a", 1: "b"}
+
+    run_knn_classification(
+        train_embeddings,
+        valid_embeddings,
+        y_train,
+        y_valid,
+        label_map,
+        tmp_path,
+        knn_neighbors=1,
+        enable_plots=False,
+    )
+
+    assert not (tmp_path / "confusion_matrix.png").exists()
 


### PR DESCRIPTION
## Summary
- allow kNN classification helper to disable confusion-matrix plotting
- add test verifying plot skipping behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b03da0df48832284d4d40ee3eba007