### PR TITLE
Enable evaluation plots

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -19,6 +19,7 @@ evaluation:
   test_size: 0.2
   random_state: 42
   knn_neighbors: 5
+  enable_plots: true
 
 wandb:
   project: "CEBRA_NLP_Experiment"


### PR DESCRIPTION
## Summary
- allow plotting during evaluation via `enable_plots`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b03d9f1a78832295004c1020372ea6