### PR TITLE
Fix duplicate enable_plots parameter in run_consistency_check

### DIFF
--- a/src/results.py
+++ b/src/results.py
@@ -231,9 +231,8 @@ def run_consistency_check(
     cfg: AppConfig,
     output_dir: Path,
     y_valid=None,
-    enable_plots=True,
-    step: int | None = None,
     enable_plots: bool = True,
+    step: int | None = None,
 ):
 
     print("\n--- Step 6: Running Consistency Check ---")


### PR DESCRIPTION
## Summary
- Fix SyntaxError by removing duplicate `enable_plots` parameter in `run_consistency_check`
- Ensure `run_consistency_check` signature expects `enable_plots` only once

## Testing
- `pytest tests/test_results.py::test_run_consistency_check` *(fails: not found)*
- `pytest tests/test_results.py::test_consistency_check_runs_without_value_error -q`


------
https://chatgpt.com/codex/tasks/task_b_68b04b083be883228895689d76f1242d