### PR TITLE
Use discrete distributions for label sampling in CEBRA

### DIFF
--- a/conf/cebra/offset1-model.yaml
+++ b/conf/cebra/offset1-model.yaml
@@ -18,4 +18,5 @@ params:
   learning_rate: 3e-4 # Higher learning rate
   temperature: 1.0
   distance: 'cosine' # Different distance metric
+  prior: 'uniform'
   verbose: True

--- a/src/cebra_trainer.py
+++ b/src/cebra_trainer.py
@@ -6,6 +6,7 @@ from tqdm.auto import tqdm
 from collections import deque
 import wandb
 import warnings
+from cebra.distributions.discrete import DiscreteUniform, DiscreteEmpirical
 
 def get_cebra_config_hash(cfg):
     import json, hashlib
@@ -207,28 +208,44 @@ def train_cebra(X_vectors, labels, cfg: AppConfig, output_dir):
 
     from cebra.models.criterions import FixedCosineInfoNCE as InfoNCE
 
-    tensors = [torch.as_tensor(X_vectors, dtype=torch.float32)]
+    X_tensor = torch.as_tensor(X_vectors, dtype=torch.float32)
+    label_tensor = None
+    dist = None
     if labels is not None:
         dtype = (
             torch.float32
             if loss_type == "mse"
             else (torch.long if cfg.cebra.conditional == "discrete" else torch.float32)
         )
-        tensors.append(torch.as_tensor(labels, dtype=dtype))
-    dataset = TensorDataset(*tensors)
-    sampler = DistributedSampler(
-        dataset, num_replicas=cfg.ddp.world_size, rank=cfg.ddp.rank
-    )
-    loader = DataLoader(
-        dataset,
-        batch_size=cfg.cebra.params.get("batch_size", 512),
-        sampler=sampler,
-        num_workers=cfg.cebra.num_workers,
-        # Use pinned memory only when running on CUDA to avoid warnings on MPS
-        pin_memory=cfg.cebra.pin_memory and cfg.device.startswith("cuda"),
-        persistent_workers=cfg.cebra.persistent_workers if cfg.cebra.num_workers > 0 else False,
-        prefetch_factor=cfg.cebra.prefetch_factor if cfg.cebra.num_workers > 0 else None,
-    )
+        label_tensor = torch.as_tensor(labels, dtype=dtype)
+        if cfg.cebra.conditional == "discrete" and loss_type != "mse":
+            X_tensor = X_tensor.to(cfg.device)
+            label_tensor = label_tensor.to(cfg.device)
+            if cfg.cebra.params.get("prior", "uniform") == "uniform":
+                dist = DiscreteUniform(label_tensor, device=cfg.device)
+            else:
+                dist = DiscreteEmpirical(label_tensor, device=cfg.device)
+
+    loader = None
+    sampler = None
+    if dist is None:
+        tensors = [X_tensor]
+        if label_tensor is not None:
+            tensors.append(label_tensor)
+        dataset = TensorDataset(*tensors)
+        sampler = DistributedSampler(
+            dataset, num_replicas=cfg.ddp.world_size, rank=cfg.ddp.rank
+        )
+        loader = DataLoader(
+            dataset,
+            batch_size=cfg.cebra.params.get("batch_size", 512),
+            sampler=sampler,
+            num_workers=cfg.cebra.num_workers,
+            # Use pinned memory only when running on CUDA to avoid warnings on MPS
+            pin_memory=cfg.cebra.pin_memory and cfg.device.startswith("cuda"),
+            persistent_workers=cfg.cebra.persistent_workers if cfg.cebra.num_workers > 0 else False,
+            prefetch_factor=cfg.cebra.prefetch_factor if cfg.cebra.num_workers > 0 else None,
+        )
 
     model = _build_model(cfg, X_vectors.shape[1])
 
@@ -272,22 +289,67 @@ def train_cebra(X_vectors, labels, cfg: AppConfig, output_dir):
     steps = 0
     skipped = 0
     ma = deque(maxlen=50)
-    epoch = 0
 
-    with tqdm(total=cfg.cebra.max_iterations, desc="CEBRA Training") as pbar:
-        while steps < cfg.cebra.max_iterations:
-            sampler.set_epoch(epoch)
-            for batch in loader:
-                if loss_type == "mse":
-                    batch_x, batch_y = batch
-                    embeddings = model(batch_x.to(cfg.device, non_blocking=True))
-                    if isinstance(embeddings, tuple):
-                        embeddings = embeddings[0]
-                    loss = criterion(
-                        embeddings, batch_y.to(cfg.device, non_blocking=True)
-                    )
-                else:
-                    if labels is None:
+    if dist is not None:
+        batch_size = cfg.cebra.params.get("batch_size", 512)
+        with tqdm(total=cfg.cebra.max_iterations, desc="CEBRA Training") as pbar:
+            while steps < cfg.cebra.max_iterations:
+                anchor_idx = dist.sample_prior(batch_size)
+                pos_idx = dist.sample_conditional(label_tensor[anchor_idx])
+                same_mask = pos_idx == anchor_idx
+                while torch.any(same_mask):
+                    resample = dist.sample_conditional(label_tensor[anchor_idx[same_mask]])
+                    pos_idx[same_mask] = resample
+                    same_mask = pos_idx == anchor_idx
+
+                neg_idx = dist.sample_prior(batch_size)
+                neg_mask = label_tensor[neg_idx] != label_tensor[anchor_idx]
+                while not torch.all(neg_mask):
+                    resample = dist.sample_prior((~neg_mask).sum())
+                    neg_idx[~neg_mask] = resample
+                    neg_mask = label_tensor[neg_idx] != label_tensor[anchor_idx]
+
+                anchor_x = X_tensor[anchor_idx]
+                pos_x = X_tensor[pos_idx]
+                neg_x = X_tensor[neg_idx]
+
+                anchor_emb = model(anchor_x)
+                if isinstance(anchor_emb, tuple):
+                    anchor_emb = anchor_emb[0]
+                pos_emb = model(pos_x)
+                if isinstance(pos_emb, tuple):
+                    pos_emb = pos_emb[0]
+                neg_emb = model(neg_x)
+                if isinstance(neg_emb, tuple):
+                    neg_emb = neg_emb[0]
+                if anchor_emb is None or pos_emb is None or neg_emb is None:
+                    raise ValueError("Model returned no embeddings")
+                loss_tuple = criterion(anchor_emb, pos_emb, neg_emb)
+                loss = loss_tuple[0] if isinstance(loss_tuple, tuple) else loss_tuple
+
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+                if wandb.run is not None:
+                    wandb.log({"loss": loss.item()}, step=steps)
+
+                steps += 1
+                pbar.update(1)
+    else:
+        epoch = 0
+        with tqdm(total=cfg.cebra.max_iterations, desc="CEBRA Training") as pbar:
+            while steps < cfg.cebra.max_iterations:
+                sampler.set_epoch(epoch)
+                for batch in loader:
+                    if loss_type == "mse":
+                        batch_x, batch_y = batch
+                        embeddings = model(batch_x.to(cfg.device, non_blocking=True))
+                        if isinstance(embeddings, tuple):
+                            embeddings = embeddings[0]
+                        loss = criterion(
+                            embeddings, batch_y.to(cfg.device, non_blocking=True)
+                        )
+                    else:
                         (batch_x,) = batch
                         embeddings = model(batch_x.to(cfg.device, non_blocking=True))
                         if isinstance(embeddings, tuple):
@@ -295,86 +357,24 @@ def train_cebra(X_vectors, labels, cfg: AppConfig, output_dir):
                         if embeddings is None:
                             raise ValueError("Model returned no embeddings")
                         loss = criterion(embeddings)
-                    else:
-                        batch_x, batch_y = batch
-                        embeddings = model(batch_x.to(cfg.device, non_blocking=True))
-                        if isinstance(embeddings, tuple):
-                            embeddings = embeddings[0]
-                        if embeddings is None:
-                            raise ValueError("Model returned no embeddings")
-                        if batch_y is None:
-                            raise ValueError("Labels are missing for supervised training")
-                        if embeddings.shape[0] != batch_y.shape[0]:
-                            raise ValueError(
-                                "Embedding batch size does not match label batch size"
-                            )
-                        labels_device = batch_y.to(cfg.device, non_blocking=True)
-                        unique, counts = torch.unique(labels_device, return_counts=True)
-                        if unique.numel() < 2 or torch.any(counts < 2):
-                            skipped += 1
-                            if wandb.run is not None:
-                                wandb.log({"skipped_batches": skipped}, step=steps)
-                            continue
-    
-                        batch_size = labels_device.shape[0]
-                        # Precompute label-wise masks to avoid per-sample loops
-                        same_mask = labels_device.unsqueeze(0) == labels_device.unsqueeze(1)
-                        same_mask.fill_diagonal_(False)
-                        diff_mask = ~same_mask
-                        diff_mask.fill_diagonal_(False)
-    
-                        # Random choices for positive/negative samples
-                        rand_pos = torch.rand(batch_size, device=labels_device.device)
-                        rand_neg = torch.rand(batch_size, device=labels_device.device)
-    
-                        same_counts = same_mask.sum(dim=1)
-                        diff_counts = diff_mask.sum(dim=1)
-                        if torch.any(same_counts == 0) or torch.any(diff_counts == 0):
-                            skipped += 1
-                            if wandb.run is not None:
-                                wandb.log({"skipped_batches": skipped}, step=steps)
-                            continue
-                        pos_choice = (rand_pos * same_counts).floor().long()
-                        neg_choice = (rand_neg * diff_counts).floor().long()
-    
-                        same_cumsum = same_mask.cumsum(dim=1) - 1
-                        diff_cumsum = diff_mask.cumsum(dim=1) - 1
-                        same_cumsum[~same_mask] = -1
-                        diff_cumsum[~diff_mask] = -1
-    
-                        pos_indices = (
-                            (same_cumsum == pos_choice.unsqueeze(1)).float().argmax(dim=1)
-                        )
-                        neg_indices = (
-                            (diff_cumsum == neg_choice.unsqueeze(1)).float().argmax(dim=1)
-                        )
-    
-                        pos_embeddings = embeddings[pos_indices]
-                        neg_embeddings = embeddings[neg_indices]
-                        loss_tuple = criterion(embeddings, pos_embeddings, neg_embeddings)
-                        loss = (
-                            loss_tuple[0]
-                            if isinstance(loss_tuple, tuple)
-                            else loss_tuple
-                        )
-    
-                optimizer.zero_grad()
-                loss.backward()
-                optimizer.step()
-                if wandb.run is not None:
+
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
+                    if wandb.run is not None:
                         wandb.log({"loss": loss.item()}, step=steps)
 
-                steps += 1
-                pbar.update(1)
-                if steps >= cfg.cebra.max_iterations:
-                    break
-            epoch += 1
+                    steps += 1
+                    pbar.update(1)
+                    if steps >= cfg.cebra.max_iterations:
+                        break
+                epoch += 1
 
     if wandb.run is not None:
         wandb.log({"total_skipped": skipped})
 
     # Explicitly shut down DataLoader workers to avoid process accumulation
-    if cfg.cebra.num_workers > 0:
+    if loader is not None and cfg.cebra.num_workers > 0:
         iterator = getattr(loader, "_iterator", None)
         if iterator is not None:
             iterator._shutdown_workers()


### PR DESCRIPTION
## Summary
- Initialize discrete label distributions and select uniform or empirical prior
- Replace mask-based positive/negative sampling with distribution-driven index sampling
- Allow configuration of prior type via `cebra.params.prior`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1651d17e88322896cb131028cc82c