### PR TITLE
Add explicit source for Emobank CSV dataset

### DIFF
--- a/conf/dataset/emobank.yaml
+++ b/conf/dataset/emobank.yaml
@@ -1,6 +1,7 @@
 # conf/dataset/emobank.yaml
 
 name: "emobank"
+source: csv
 
 hf_path: csv  # HuggingFaceの代わりにローカルCSV指定
 data_files: data/emobank.csv  # 下で使うCSVファイルのローカルパス


### PR DESCRIPTION
## Summary
- specify `source: csv` in Emobank dataset config to load local CSV

## Testing
- `python - <<'PY'
from omegaconf import OmegaConf
from datasets import load_dataset
cfg = OmegaConf.load('conf/dataset/emobank.yaml')
print('source:', cfg.get('source'))
print('hf_path:', cfg.get('hf_path'))
print('data_files:', cfg.get('data_files'))
if cfg.get('source') == 'csv':
    dataset = load_dataset('csv', data_files=cfg.get('data_files'))
else:
    dataset = load_dataset(cfg.get('hf_path'))
print('loaded splits:', list(dataset.keys()))
print('sample:', dataset[list(dataset.keys())[0]][0])
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1a522c3e8832292d90b5ebc33aef3