### PR TITLE
Ensure structured Hydra configs with default dataset source

### DIFF
--- a/macmain.py
+++ b/macmain.py
@@ -29,6 +29,8 @@ load_dotenv()
 
 @hydra.main(config_path="conf", config_name="config", version_base="1.2")
 def main(cfg: AppConfig) -> None:
+    default_cfg = OmegaConf.structured(AppConfig)
+    cfg = OmegaConf.merge(default_cfg, cfg)
     OmegaConf.set_struct(cfg, False)
     cfg.ddp.world_size = 1
     cfg.ddp.rank = 0

--- a/macmainoptimize.py
+++ b/macmainoptimize.py
@@ -29,6 +29,8 @@ load_dotenv()
 
 @hydra.main(config_path="conf", config_name="config", version_base="1.2")
 def main(cfg: AppConfig) -> None:
+    default_cfg = OmegaConf.structured(AppConfig)
+    cfg = OmegaConf.merge(default_cfg, cfg)
     OmegaConf.set_struct(cfg, False)
     cfg.ddp.world_size = 1
     cfg.ddp.rank = 0

--- a/macmainoptuna.py
+++ b/macmainoptuna.py
@@ -30,6 +30,8 @@ load_dotenv()
 
 @hydra.main(config_path="conf", config_name="config", version_base="1.2")
 def main(cfg: AppConfig) -> None:
+    default_cfg = OmegaConf.structured(AppConfig)
+    cfg = OmegaConf.merge(default_cfg, cfg)
     OmegaConf.set_struct(cfg, False)
     cfg.ddp.world_size = 1
     cfg.ddp.rank = 0

--- a/main.py
+++ b/main.py
@@ -30,6 +30,8 @@ load_dotenv()
 
 @hydra.main(config_path="conf", config_name="config", version_base="1.2")
 def main(cfg: AppConfig) -> None:
+    default_cfg = OmegaConf.structured(AppConfig)
+    cfg = OmegaConf.merge(default_cfg, cfg)
     OmegaConf.set_struct(cfg, False)
     cfg.cebra.conditional = cfg.cebra.conditional.lower()
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
@@ -86,7 +88,7 @@ def main(cfg: AppConfig) -> None:
         if cfg.cebra.conditional == 'none':
             dataset_cfg = cfg.dataset
             # データセットのソースに応じて読み込み
-            source = getattr(dataset_cfg, "source", "hf")
+            source = dataset_cfg.source
             if source == "hf":
                 dataset = load_dataset(dataset_cfg.hf_path)
             elif source == "csv":

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -16,7 +16,7 @@ class DatasetConfig:
     label_map: Dict[int, str]
     visualization: VisualizationConfig
     hf_path: Optional[str] = None
-    source: Optional[Literal["hf", "csv", "kaggle"]] = "hf"
+    source: str = "hf"
     data_files: Optional[str] = None
 
 @dataclass

--- a/tests/test_dataset_source_default.py
+++ b/tests/test_dataset_source_default.py
@@ -1,0 +1,13 @@
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.config_schema import AppConfig, DatasetConfig
+
+
+def test_dataset_source_default():
+    with initialize(version_base='1.2', config_path='../conf'):
+        cfg = compose(config_name='config', overrides=['dataset=imdb'])
+    dataset_cfg = OmegaConf.merge(OmegaConf.structured(DatasetConfig), cfg.dataset)
+    assert dataset_cfg.source == 'hf'


### PR DESCRIPTION
## Summary
- Merge default `AppConfig` into Hydra configs across entry scripts
- Default dataset `source` to `"hf"` through structured schema
- Add test confirming omission of dataset `source` uses default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b1a525794c8322a9fe16645686645b