### PR TITLE
Make dataset label column optional

### DIFF
--- a/conf/dataset/emobank.yaml
+++ b/conf/dataset/emobank.yaml
@@ -2,12 +2,9 @@
 
 name: "emobank"
 source: csv
-
-source: csv
 data_files: data/emobank.csv
 
 text_column: text
-label_column: V  # placeholder to satisfy schema
 label_map: {}
 visualization:
   emotion_colors: {}

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -12,9 +12,9 @@ class VisualizationConfig:
 class DatasetConfig:
     name: str
     text_column: str
-    label_column: str
     label_map: Dict[int, str]
     visualization: VisualizationConfig
+    label_column: Optional[str] = None
     hf_path: Optional[str] = None
     source: str = "hf"
     data_files: Optional[str] = None

--- a/src/data.py
+++ b/src/data.py
@@ -32,7 +32,7 @@ def load_and_prepare_dataset(cfg: "AppConfig"):
     df = pd.concat(all_splits, ignore_index=True)
     
     # Special handling for go_emotions: use only the first label
-    if dataset_cfg.name == "go_emotions":
+    if dataset_cfg.name == "go_emotions" and dataset_cfg.label_column is not None:
         print("Applying special handling for go_emotions: using only the first label.")
         df[dataset_cfg.label_column] = df[dataset_cfg.label_column].apply(lambda x: x[0])
 
@@ -42,6 +42,10 @@ def load_and_prepare_dataset(cfg: "AppConfig"):
         conditional_data = df[["V", "A", "D"]].to_numpy(dtype=np.float32)
         texts = df[dataset_cfg.text_column].astype(str)
     else:
+        if dataset_cfg.label_column is None:
+            raise ValueError(
+                "dataset.label_column must be set when cfg.cebra.conditional is not 'None'"
+            )
         labels = df[dataset_cfg.label_column]
         df = df.dropna(subset=[dataset_cfg.text_column, dataset_cfg.label_column]).reset_index(drop=True)
         conditional_data = labels.to_numpy()


### PR DESCRIPTION
## Summary
- Allow `DatasetConfig.label_column` to be optional
- Handle missing `label_column` in data loader
- Remove placeholder label column from `emobank` dataset config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b31373a9788322a4239d0490938e2c